### PR TITLE
fix: .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,8 +7,5 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = false
 insert_final_newline = true
-indent_style = tab
-
-[*.json]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
Before this commit, indentation style and size were `tabs` and `default`.

This is because I'd never updated it to fit the project after transitioning from `generator-react-component`. Also, I didn't have editorconfig setup in emacs so I didn't even know it was wronge.

Now, indentation is set to `space` and `2`.