### PR TITLE
Style: fix cut-off column in table

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -14,6 +14,8 @@ table {
   padding:0;
   border-collapse: collapse;
   border-spacing: 0;
+  overflow-x: auto;
+  display: block;
 }
 
 table tr {


### PR DESCRIPTION
The table gets cut off in the `Lifecycle methods` section, yet users aren't able to horizontally scroll. This fixes that by adding horizontal scrolling to the table element.

Screenshot of the issue:

<img width="723" alt="react-cheat-sheet-table" src="https://user-images.githubusercontent.com/16869061/52296150-eddf5c80-297d-11e9-92b3-661fe5d20a8d.png">
